### PR TITLE
Routes change

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   resources :users, only: [:show]
-  resources :conversations, only: [:index, :show, :new, :create] do
+  resources :conversations, only: [:index, :show, :new, :create, :destroy] do
     resources :responses, only: [:create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,8 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  resources :users, only: [:index, :show] do
-    # except update and edit for now, in the future we can make the user change the title of the conversation
-    resources :conversations, except: [:edit, :update] do
-      resources :responses, only: [:index, :create, :show]
-    end
+  resources :users, only: [:show]
+  resources :conversations, except: [:edit, :update] do
+    resources :responses, only: [:create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   resources :users, only: [:show]
-  resources :conversations, except: [:edit, :update] do
+  resources :conversations, only: [:index, :show, :new, :create] do
     resources :responses, only: [:create]
   end
 end


### PR DESCRIPTION
# Routes Changes Explanation

## Users

**Necessary**
- `#show` – for displaying a profile page with user information

**Removed**
- `#index` – unless we need to display all users on the website for admin purposes, we won't be using this

---

## Conversations

Effectively the same, but it's much more readable to see what we're **using**.  
Before, we had to see what we were **not using** and then remember the rest.

---

## Responses

**Necessary**
- `#create` – creating new responses will be done on the conversation new/show pages.  
  It will be embedded. This is also why we don't need a `#new` action.

**Removed**
- `#index` – we will display conversations to show responses.  
  We currently have no designs that require us to display just a list of responses on their own.
- `#show` – responses will be displayed as part of the conversation show page.  
  We don’t need to show a single response on its own.
